### PR TITLE
Bump version number before publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+npm-debug.log
 .idea/
 *~
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hogan-cached",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Express view engine that renders Mustache with Hogan.js and caches compiled templates for more speed",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi Guilherme,

I'm bumping the version so that I can publish to npm.  I assume you want to follow semver, so I'm bumping the major number. I'm doing this because I removed the public `setBaseDir()` since the last version was published.  If you're OK with this, please lgtm this change and I'll merge the pull request and then publish.  Thanks.